### PR TITLE
back-end: Adicionar dependência de criptografia ao core e configuração inicial de segurança

### DIFF
--- a/votify-api/src/main/java/br/com/votify/api/configuration/SecurityConfig.java
+++ b/votify-api/src/main/java/br/com/votify/api/configuration/SecurityConfig.java
@@ -1,0 +1,14 @@
+package br.com.votify.api.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/votify-core/pom.xml
+++ b/votify-core/pom.xml
@@ -18,7 +18,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>6.4.2</version>
+        </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>


### PR DESCRIPTION
A dependência adicionada ao votify-core é o spring-security-crypto necessária para criptografar a senha dos usuários

Também foi adicionado a classe SecurityConfig para futuras edições de segurança da API, por enquanto é apenas para adicionar um bean de um encoder Bcrypt

Eu iria adicionar no próprio pull request #23, mas acho que é melhor fazer aqui