### PR TITLE
feature/k8s-mysql-acesso-cluster-externo-#120

### DIFF
--- a/k8s/mysql/mysql-service-cluster.yaml
+++ b/k8s/mysql/mysql-service-cluster.yaml
@@ -1,0 +1,17 @@
+# Acesso interno (IP fixo)
+
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-svc-cluster
+  namespace: votify
+spec:
+  selector:
+    app: mysql
+  type: ClusterIP
+  clusterIP: 10.96.0.50
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/k8s/mysql/mysql-service-node.yaml
+++ b/k8s/mysql/mysql-service-node.yaml
@@ -1,0 +1,16 @@
+# Acesso externo (NodePort)
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-svc-node
+  namespace: votify
+spec:
+  selector:
+    app: mysql
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+      nodePort: 30006


### PR DESCRIPTION
### O que foi feito
- Deploy MySQL no namespace `votify`
- Serviço interno com IP fixo: `10.96.0.50`
- Serviço externo via NodePort: `localhost:60975`

### Testes realizados
- Minikube + Docker (local)
- Acesso validado com DBeaver
- Secret aplicado com senha root do MySQL

### Issue relacionada
Closes #120
